### PR TITLE
Add correct BN tag filters

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
       "git_repo": "CleverRaven/Cataclysm-DDA",
       "filters": [ "^0\\.([0-9]+|[A-Z]).*", "^cdda-0\\.([0-9]+|[A-Z]).*", "^cdda-experimental-.*", "^experimental-.*" ]
     },
-    { "game_name": "bn", "git_repo": "cataclysmbnteam/Cataclysm-BN", "filters": [ ".*" ] },
+    { "game_name": "bn", "git_repo": "cataclysmbnteam/Cataclysm-BN", "filters": [ "^v[0-9]+\\.[0-9]+", "^[0-9]+-[0-9]+", "^cbn-0\\.[0-9]+" ] },
     { "game_name": "tlg", "git_repo": "Cataclysm-TLG/Cataclysm-TLG", "filters": [ ".*" ] }
   ]
 }


### PR DESCRIPTION
Hi!

I figured I'd fill out the BN tag filters properly, since DDA has theirs filled out.

These match, in order: Current Stables, Current Nightlies, and pre-0.6 stables (I did not bother dealing with old BN experimentals)